### PR TITLE
Removing disabled origin shield block to optimize updates.

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -25,10 +25,6 @@ resource "aws_cloudfront_distribution" "distribution" {
   origin {
     origin_id = aws_s3_bucket.bucket.id
     domain_name = aws_s3_bucket.bucket.bucket_domain_name
-    origin_shield {
-      enabled = false
-      origin_shield_region = var.region
-    }
   }
   default_root_object = "index.html"
   price_class = "PriceClass_All"


### PR DESCRIPTION
The disabled origin shield block in the terraform script causes terraform to forever see a difference between what is deployed and what is in the script, because it thinks it needs to keep applying the disabled origin shield.  It can take minutes to redeploy CloudFront because of this, when really nothing has changed.