### PR TITLE
Work around an awkward situation with autoDetectRenderer.

### DIFF
--- a/src/devices/PixiRenderer.ts
+++ b/src/devices/PixiRenderer.ts
@@ -12,7 +12,7 @@ export class PixiRenderer implements Renderer {
     private readonly _containerElement!: HTMLElement;
     private _world!: World;
     private _worldDimensions!: Dimensions;
-    private _renderer!: PIXI.AbstractRenderer;//PIXI.Renderer;
+    private _renderer!: PIXI.Renderer;
     private _stage!: PIXI.Container;
     private _isActiveSprites: Map<string, SpriteDetail> = new Map<string, SpriteDetail>();
     private _isActiveTexts: Map<string, PIXI.Text> = new Map<string, PIXI.Text>();
@@ -43,7 +43,7 @@ export class PixiRenderer implements Renderer {
         this._renderer = PIXI.autoDetectRenderer({
             width: this._worldDimensions.width,
             height: this._worldDimensions.height
-        });
+        }) as PIXI.Renderer;
         this._renderer.backgroundColor = 0x000000;
         this._containerElement.appendChild(this._renderer.view);
         this._stage = new PIXI.Container();


### PR DESCRIPTION
Somehow, we're supposed to either get a instance of Renderer or CanvasRenderer back from autoDetectRenderer, but it doesn't seem to work out right.  They both extend AbstractRenderer, but that class does not have a render method so it's of no use.  The autoDetectRenderer method appears to return Renderer despite the fact that it could actually return CanvasRenderer... but it seems we must cast to make vscode happy.  Anyway, it seems to work.